### PR TITLE
Neo4j 5 Syntax Update

### DIFF
--- a/langchain4j-neo4j/src/test/java/dev/langchain4j/store/embedding/neo4j/Neo4jEmbeddingStoreIT.java
+++ b/langchain4j-neo4j/src/test/java/dev/langchain4j/store/embedding/neo4j/Neo4jEmbeddingStoreIT.java
@@ -49,9 +49,9 @@ class Neo4jEmbeddingStoreIT {
     public static final String USERNAME = "neo4j";
     public static final String ADMIN_PASSWORD = "adminPass";
     public static final String LABEL_TO_SANITIZE = "Label ` to \\ sanitize";
-    
+
     @Container
-    static Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>(DockerImageName.parse("neo4j:5.14.0"))
+    static Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>(DockerImageName.parse("neo4j:5.26.0"))
             .withAdminPassword(ADMIN_PASSWORD);
 
     private static final String METADATA_KEY = "test-key";
@@ -59,7 +59,7 @@ class Neo4jEmbeddingStoreIT {
     private EmbeddingStore<TextSegment> embeddingStore;
 
     private final EmbeddingModel embeddingModel = new AllMiniLmL6V2QuantizedEmbeddingModel();
-    private static Session session; 
+    private static Session session;
 
 
     @BeforeAll
@@ -101,7 +101,7 @@ class Neo4jEmbeddingStoreIT {
         assertThat(match.embedding()).isEqualTo(embedding);
         assertThat(match.embedded()).isNull();
 
-        checkEntitiesCreated(relevant.size(), 
+        checkEntitiesCreated(relevant.size(),
                 iterator -> checkDefaultProps(embedding, match, iterator.next()));
     }
 
@@ -122,7 +122,7 @@ class Neo4jEmbeddingStoreIT {
         assertThat(match.embedding()).isEqualTo(embedding);
         assertThat(match.embedded()).isNull();
 
-        checkEntitiesCreated(relevant.size(), 
+        checkEntitiesCreated(relevant.size(),
                 iterator -> checkDefaultProps(embedding, match, iterator.next()));
     }
 
@@ -144,11 +144,11 @@ class Neo4jEmbeddingStoreIT {
         assertThat(match.embedding()).isEqualTo(embedding);
         assertThat(match.embedded()).isEqualTo(segment);
 
-        checkEntitiesCreated(relevant.size(), 
+        checkEntitiesCreated(relevant.size(),
                 iterator -> {
-            List<String> otherProps = Collections.singletonList(DEFAULT_TEXT_PROP);
-            checkDefaultProps(embedding, match, iterator.next(), otherProps);
-        });
+                    List<String> otherProps = Collections.singletonList(DEFAULT_TEXT_PROP);
+                    checkDefaultProps(embedding, match, iterator.next(), otherProps);
+                });
     }
 
     @Test
@@ -167,7 +167,7 @@ class Neo4jEmbeddingStoreIT {
                 .label(labelName)
                 .indexName("customIdxName")
                 .build();
-        
+
         String metadataCompleteKey = metadataPrefix + METADATA_KEY;
 
         checkSegmentWithMetadata(metadataCompleteKey, labelName);
@@ -253,7 +253,7 @@ class Neo4jEmbeddingStoreIT {
         assertThat(secondMatch.embedding()).isEqualTo(secondEmbedding);
         assertThat(secondMatch.embedded()).isNull();
 
-        checkEntitiesCreated(relevant.size(), 
+        checkEntitiesCreated(relevant.size(),
                 iterator -> {
                     iterator.forEachRemaining(node -> {
                         if (node.get(DEFAULT_ID_PROP).asString().equals(firstMatch.embeddingId())) {
@@ -262,7 +262,7 @@ class Neo4jEmbeddingStoreIT {
                             checkDefaultProps(secondEmbedding, secondMatch, node);
                         }
                     });
-        });
+                });
     }
 
     @Test
@@ -362,7 +362,7 @@ class Neo4jEmbeddingStoreIT {
                             checkDefaultProps(secondEmbedding, secondMatch, node);
                         }
                     });
-        });
+                });
     }
 
     @Test
@@ -383,7 +383,7 @@ class Neo4jEmbeddingStoreIT {
                 RelevanceScore.fromCosineSimilarity(CosineSimilarity.between(embedding, referenceEmbedding)),
                 withPercentage(1)
         );
-        
+
         checkEntitiesCreated(relevant.size(),
                 iterator -> checkDefaultProps(embedding, match, iterator.next()));
     }
@@ -392,7 +392,7 @@ class Neo4jEmbeddingStoreIT {
     void should_throw_error_if_another_index_name_with_different_label_exists() {
         String metadataPrefix = "metadata.";
         String idxName = "WillFail";
-        
+
         embeddingStore = Neo4jEmbeddingStore.builder()
                 .withBasicAuth(neo4jContainer.getBoltUrl(), USERNAME, ADMIN_PASSWORD)
                 .dimension(384)
@@ -494,7 +494,7 @@ class Neo4jEmbeddingStoreIT {
                 SchemaNames.sanitize(labelName).get(),
                 DEFAULT_TEXT_PROP
         );
-        
+
         List<Node> n = session.run(query)
                 .list(i -> i.get("n").asNode());
 


### PR DESCRIPTION
Updated vector index creation

The `indexExists()` still remains, since it throws an error with an existing indexes with the same name but different label/props.
As implemented in langchain-ai [here](https://github.com/langchain-ai/langchain/blob/master/libs/community/langchain_community/vectorstores/neo4j_vector.py#L883)